### PR TITLE
Add Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)

### DIFF
--- a/insider.html
+++ b/insider.html
@@ -95,7 +95,9 @@
 								<summary>Last Week In Bitcoin</summary>
 								<ul>
 									<ul>
-										<li id="latest"><a href="https://insider.btcpp.dev/p/more-space-for-miners-last-week-in" target="_blank">
+										<li id="latest"><a href="https://insider.btcpp.dev/p/talking-controversies-last-week-in" target="_blank">
+											Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)</a></li>
+									<li><a href="https://insider.btcpp.dev/p/more-space-for-miners-last-week-in" target="_blank">
 											More Space for Miners — Last Week in Bitcoin (Apr 20 - 26)</a></li>
 										<li><a href="https://insider.btcpp.dev/p/time-for-releases-last-week-in-bitcoin" target="_blank">
 											Time For Releases — Last Week in Bitcoin (Apr 13 - 19)</a></li>

--- a/insider.html
+++ b/insider.html
@@ -97,7 +97,7 @@
 									<ul>
 										<li id="latest"><a href="https://insider.btcpp.dev/p/talking-controversies-last-week-in" target="_blank">
 											Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)</a></li>
-									<li><a href="https://insider.btcpp.dev/p/more-space-for-miners-last-week-in" target="_blank">
+										<li><a href="https://insider.btcpp.dev/p/more-space-for-miners-last-week-in" target="_blank">
 											More Space for Miners — Last Week in Bitcoin (Apr 20 - 26)</a></li>
 										<li><a href="https://insider.btcpp.dev/p/time-for-releases-last-week-in-bitcoin" target="_blank">
 											Time For Releases — Last Week in Bitcoin (Apr 13 - 19)</a></li>


### PR DESCRIPTION
Adds the latest Insider Edition entry:

**Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)**
https://insider.btcpp.dev/p/talking-controversies-last-week-in

Inserted at the top of the Last Week in Bitcoin section.