### PR TITLE
Add New Lightning Channels — Last Week in Bitcoin (May 04 - 10)

### DIFF
--- a/insider.html
+++ b/insider.html
@@ -95,7 +95,9 @@
 								<summary>Last Week In Bitcoin</summary>
 								<ul>
 									<ul>
-										<li id="latest"><a href="https://insider.btcpp.dev/p/talking-controversies-last-week-in" target="_blank">
+										<li id="latest"><a href="https://insider.btcpp.dev/p/new-lightning-channels-last-week" target="_blank">
+											New Lightning Channels — Last Week in Bitcoin (May 04 - 10)</a></li>
+										<li><a href="https://insider.btcpp.dev/p/talking-controversies-last-week-in" target="_blank">
 											Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)</a></li>
 										<li><a href="https://insider.btcpp.dev/p/more-space-for-miners-last-week-in" target="_blank">
 											More Space for Miners — Last Week in Bitcoin (Apr 20 - 26)</a></li>


### PR DESCRIPTION
Adds the latest Insider Edition entry:

**New Lightning Channels — Last Week in Bitcoin (May 04 - 10)**
https://insider.btcpp.dev/p/new-lightning-channels-last-week

Inserted at the top of the Last Week in Bitcoin section in `insider.html`.