### PR TITLE
Add The Rust SDK — The ContextVM World #8

### DIFF
--- a/cvm.html
+++ b/cvm.html
@@ -92,7 +92,11 @@
 								<summary><strong>The ContextVM World</strong></summary>
 								<ul>
 									<ul>
-										<li id="latest"><a href="https://primal.net/a/naddr1qvzqqqr4gupzq6ehsrhjjuh885mshp9ru50842dwxjl5z2fcmnaan30k8v3pg9kgqqrxxand94mnwcdrt4w" target="_blank">
+										<li id="latest"><a href="https://primal.net/a/naddr1qvzqqqr4gupzq6ehsrhjjuh885mshp9ru50842dwxjl5z2fcmnaan30k8v3pg9kgqqrxxandwuknsy3reu7" target="_blank">
+											The Rust SDK — The ContextVM World #8 🌍</a></li>
+									</ul>
+									<ul>
+										<li><a href="https://primal.net/a/naddr1qvzqqqr4gupzq6ehsrhjjuh885mshp9ru50842dwxjl5z2fcmnaan30k8v3pg9kgqqrxxand94mnwcdrt4w" target="_blank">
 											Public Presence — The ContextVM World #7 🌍</a></li>
 									</ul>
 									<ul>


### PR DESCRIPTION
Adds the latest ContextVM World entry:

**The Rust SDK — The ContextVM World #8 🌍**
https://primal.net/a/naddr1qvzqqqr4gupzq6ehsrhjjuh885mshp9ru50842dwxjl5z2fcmnaan30k8v3pg9kgqqrxxandwuknsy3reu7

Inserted at the top of the contributions list in `cvm.html`, with `id="latest"` moved to the new entry.