### PR TITLE
Add Bitcoin Optech Newsletter #405

### DIFF
--- a/optech.html
+++ b/optech.html
@@ -51,7 +51,18 @@
 							</header>
 							<h3>Contributions</h3>
 							<dl>
-								<dt id="latest">Bitcoin Optech Newsletter #404</dt>
+								<dt id="latest">Bitcoin Optech Newsletter #405</dt>
+								<dd>
+									<ul>
+										<li><a 
+											href="https://bitcoinops.org/en/newsletters/2026/05/15/#bip-proposal-for-utxo-set-sharing-over-p2p-network" target="_blank"
+											>
+											BIP proposal for UTXO set sharing over P2P network
+											</a>
+										</li>
+									</ul>
+								</dd>
+								<dt>Bitcoin Optech Newsletter #404</dt>
 								<dd>
 									<ul>
 										<li><a 


### PR DESCRIPTION
Adds contribution from Newsletter #405:

- [BIP proposal for UTXO set sharing over P2P network](https://bitcoinops.org/en/newsletters/2026/05/15/#bip-proposal-for-utxo-set-sharing-over-p2p-network)

Inserted at the top of `optech.html` with `id="latest"` moved to the new entry.