### PR TITLE
Add two Insider contributions (May 19)

### DIFF
--- a/insider.html
+++ b/insider.html
@@ -85,7 +85,9 @@
 								<summary>Technical Takes</summary>
 								<ul>
 									<ul>
-										<li id="latest-tech"><a href="https://insider.btcpp.dev/p/clboss" target="_blank">
+										<li id="latest-tech"><a href="https://insider.btcpp.dev/p/how-to-make-smaller-post-quantum" target="_blank">
+											How To Make Smaller Post-Quantum Signatures</a></li>
+										<li><a href="https://insider.btcpp.dev/p/clboss" target="_blank">
 											CLBOSS: Can a Lightning Node Learn Austrian Economics?</a></li>
 									</ul>
 								</ul>
@@ -95,7 +97,9 @@
 								<summary>Last Week In Bitcoin</summary>
 								<ul>
 									<ul>
-										<li id="latest"><a href="https://insider.btcpp.dev/p/new-lightning-channels-last-week" target="_blank">
+										<li id="latest"><a href="https://insider.btcpp.dev/p/improving-backups-last-week-in-bitcoin" target="_blank">
+											Improving Backups — Last Week in Bitcoin (May 11 - 17)</a></li>
+										<li><a href="https://insider.btcpp.dev/p/new-lightning-channels-last-week" target="_blank">
 											New Lightning Channels — Last Week in Bitcoin (May 04 - 10)</a></li>
 										<li><a href="https://insider.btcpp.dev/p/talking-controversies-last-week-in" target="_blank">
 											Talking Controversies — Last Week in Bitcoin (Apr 27 - May 03)</a></li>


### PR DESCRIPTION
Adds two new Insider Edition contributions:

**Last Week in Bitcoin:**
- [Improving Backups — Last Week in Bitcoin (May 11 - 17)](https://insider.btcpp.dev/p/improving-backups-last-week-in-bitcoin)

**Technical Takes:**
- [How To Make Smaller Post-Quantum Signatures](https://insider.btcpp.dev/p/how-to-make-smaller-post-quantum)

Both inserted at the top of their respective sections in `insider.html`, with `id` anchors updated.