### PR TITLE
Add Seventeenth Wave of Nostr Grants

### DIFF
--- a/opensats.html
+++ b/opensats.html
@@ -95,7 +95,10 @@
 								<summary><strong>OpenSats Editor Contributions</strong></summary>
 								<ul>
 									<ul>
-										<li id="latest-editor"><a href="https://opensats.org/blog/open-hardware-for-open-money" target="_blank">
+										<li id="latest-editor"><a href="https://opensats.org/blog/seventeenth-wave-of-nostr-grants" target="_blank">
+											Seventeenth Wave of Nostr Grants</a>
+										</li>
+										<li><a href="https://opensats.org/blog/open-hardware-for-open-money" target="_blank">
 											Open Hardware for Open Money</a>
 										</li>
 										<li><a href="https://opensats.org/blog/sixteenth-wave-of-nostr-grants" target="_blank">


### PR DESCRIPTION
Adds OpenSats editor contribution:

- [Seventeenth Wave of Nostr Grants](https://opensats.org/blog/seventeenth-wave-of-nostr-grants)

Inserted at the top of OpenSats Editor Contributions in `opensats.html`.