### PR TITLE
Add Bitcoin Optech Newsletter #406

### DIFF
--- a/optech.html
+++ b/optech.html
@@ -51,7 +51,18 @@
 							</header>
 							<h3>Contributions</h3>
 							<dl>
-								<dt id="latest">Bitcoin Optech Newsletter #405</dt>
+								<dt id="latest">Bitcoin Optech Newsletter #406</dt>
+								<dd>
+									<ul>
+										<li><a 
+											href="https://bitcoinops.org/en/newsletters/2026/05/22/#tcp-hole-punching-for-bitcoin-nodes-behind-nats" target="_blank"
+											>
+											TCP hole punching for Bitcoin nodes behind NATs
+											</a>
+										</li>
+									</ul>
+								</dd>
+								<dt>Bitcoin Optech Newsletter #405</dt>
 								<dd>
 									<ul>
 										<li><a 


### PR DESCRIPTION
Adds contribution from Newsletter #406:

- [TCP hole punching for Bitcoin nodes behind NATs](https://bitcoinops.org/en/newsletters/2026/05/22/#tcp-hole-punching-for-bitcoin-nodes-behind-nats)

Inserted at the top of `optech.html`.