### PR TITLE
Add favicon link to all pages

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -9,6 +9,7 @@
 		<title>My Contacts</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>

--- a/cvm.html
+++ b/cvm.html
@@ -9,6 +9,7 @@
 		<title>The ContextVM World</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	

--- a/ibc.html
+++ b/ibc.html
@@ -9,6 +9,7 @@
 		<title>Inside Bitcoin Code</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	

--- a/insider.html
+++ b/insider.html
@@ -9,6 +9,7 @@
 		<title>BTC++ Contributions</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	

--- a/opensats.html
+++ b/opensats.html
@@ -9,6 +9,7 @@
 		<title>OpenSats</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	

--- a/optech.html
+++ b/optech.html
@@ -9,6 +9,7 @@
 		<title>Optech Contributions</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	

--- a/portfolio.html
+++ b/portfolio.html
@@ -9,6 +9,7 @@
 		<title>My Portfolio</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="icon" type="image/png" href="images/logo-smile.png" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 		<style>


### PR DESCRIPTION
Adds the same favicon `<link>` tag present in index.html to the following pages:

- contacts.html
- cvm.html
- ibc.html
- insider.html
- opensats.html
- optech.html
- portfolio.html

Favicon: `<link rel="icon" type="image/png" href="images/logo-smile.png" />`

Skipped: photoreportage.html (as requested)