### PR TITLE
Update tip link to 'Zap Me a Coffee' on all pages

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -210,7 +210,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/cvm.html
+++ b/cvm.html
@@ -224,7 +224,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/ibc.html
+++ b/ibc.html
@@ -210,7 +210,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/insider.html
+++ b/insider.html
@@ -329,7 +329,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/opensats.html
+++ b/opensats.html
@@ -173,7 +173,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/optech.html
+++ b/optech.html
@@ -416,7 +416,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/photoreportage.html
+++ b/photoreportage.html
@@ -226,7 +226,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>

--- a/portfolio.html
+++ b/portfolio.html
@@ -270,7 +270,7 @@
 
 				<!-- Copyright -->
 					<div id="copyright">
-						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://getalby.com/p/tuma" target="_blank">tuma@getalby.com</a></li></ul>
+						<ul><li>&copy; Tuma</li><li>Tip: <a href="https://tumabitcoiner.github.io/ln-tip-web-app/" target="_blank">Zap Me a Coffee</a></li></ul>
 					</div>
 
 			</div>


### PR DESCRIPTION
Replaces the old Alby tip link with the new 'Zap Me a Coffee' link on all pages:

Old: `https://getalby.com/p/tuma` (tuma@getalby.com)
New: `https://tumabitcoiner.github.io/ln-tip-web-app/` (Zap Me a Coffee)

Updated pages:
- portfolio.html
- contacts.html
- optech.html
- insider.html
- opensats.html
- cvm.html
- ibc.html
- photoreportage.html