### PR TITLE
Add Bitcoin Optech Newsletter #408

### DIFF
--- a/optech.html
+++ b/optech.html
@@ -52,7 +52,18 @@
 							</header>
 							<h3>Contributions</h3>
 							<dl>
-								<dt id="latest">Bitcoin Optech Newsletter #406</dt>
+								<dt id="latest">Bitcoin Optech Newsletter #408</dt>
+								<dd>
+									<ul>
+										<li><a 
+											href="https://bitcoinops.org/en/newsletters/2026/06/05/#a-post-quantum-path-for-bip324" target="_blank"
+											>
+											A post-quantum path for BIP324
+											</a>
+										</li>
+									</ul>
+								</dd>
+								<dt>Bitcoin Optech Newsletter #406</dt>
 								<dd>
 									<ul>
 										<li><a 


### PR DESCRIPTION
Adds contribution from Newsletter #408:

- [A post-quantum path for BIP324](https://bitcoinops.org/en/newsletters/2026/06/05/#a-post-quantum-path-for-bip324)

Inserted at the top of `optech.html`.