### PR TITLE
Add Bitcoin Optech Newsletter #409

### DIFF
--- a/optech.html
+++ b/optech.html
@@ -52,7 +52,18 @@
 							</header>
 							<h3>Contributions</h3>
 							<dl>
-								<dt id="latest">Bitcoin Optech Newsletter #408</dt>
+								<dt id="latest">Bitcoin Optech Newsletter #409</dt>
+								<dd>
+									<ul>
+										<li><a 
+											href="https://bitcoinops.org/en/newsletters/2026/06/12/#draft-bip-for-testnet5" target="_blank"
+											>
+											Draft BIP for testnet5
+											</a>
+										</li>
+									</ul>
+								</dd>
+								<dt>Bitcoin Optech Newsletter #408</dt>
 								<dd>
 									<ul>
 										<li><a 


### PR DESCRIPTION
Adds contribution from Newsletter #409:

- [Draft BIP for testnet5](https://bitcoinops.org/en/newsletters/2026/06/12/#draft-bip-for-testnet5)

Inserted at the top of `optech.html`.