### PR TITLE
Add New Specs for Marmot — Last Week in Bitcoin (Jun 08-14)

### DIFF
--- a/insider.html
+++ b/insider.html
@@ -98,7 +98,9 @@
 								<summary>Last Week In Bitcoin</summary>
 								<ul>
 									<ul>
-										<li id="latest"><a href="https://insider.btcpp.dev/p/p2p-utxo-set-sharing-last-week-in" target="_blank">
+										<li id="latest"><a href="https://insider.btcpp.dev/p/new-specs-for-marmot-last-week-in" target="_blank">
+											New Specs for Marmot — Last Week in Bitcoin (Jun 08 - 14)</a></li>
+										<li><a href="https://insider.btcpp.dev/p/p2p-utxo-set-sharing-last-week-in" target="_blank">
 											P2P UTXO Set Sharing — Last Week in Bitcoin (Jun 01 - 07)</a></li>
 										<li><a href="https://insider.btcpp.dev/p/economics-edition-last-week-in-bitcoin" target="_blank">
 											Economics Edition — Last Week in Bitcoin (May 25 - 31)</a></li>


### PR DESCRIPTION
Adds the latest Insider Edition LWIB entry:

**New Specs for Marmot — Last Week in Bitcoin (Jun 08 - 14)**
https://insider.btcpp.dev/p/new-specs-for-marmot-last-week-in

Inserted at the top of Last Week in Bitcoin section.