### PR TITLE
Replace Egge with Calvin Kim in OpenSats editor contributions

### DIFF
--- a/opensats.html
+++ b/opensats.html
@@ -96,8 +96,8 @@
 								<summary><strong>OpenSats Editor Contributions</strong></summary>
 								<ul>
 									<ul>
-										<li id="latest-editor"><a href="https://opensats.org/blog/developer-spotlight-egge-coco" target="_blank">
-											Egge's Bitcoin Journey: From Marketer to Cashu Maintainer</a>
+										<li id="latest-editor"><a href="https://opensats.org/blog/calvin-kim-receives-lts-grant" target="_blank">
+											Long-Term Support For Calvin Kim</a>
 										</li>
 										<li><a href="https://opensats.org/blog/the-libraries-behind-open-communication" target="_blank">
 											The Libraries Behind Open Communication</a>


### PR DESCRIPTION
Updates OpenSats editor contributions:

**Removed:**
- Egge's Bitcoin Journey: From Marketer to Cashu Maintainer

**Added:**
- [Long-Term Support For Calvin Kim](https://opensats.org/blog/calvin-kim-receives-lts-grant)